### PR TITLE
Add audio file route and endpoint

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -54,6 +54,23 @@ export const ourFileRouter = {
       console.log("file url", file.ufsUrl);
       return { uploadedBy: metadata.userId };
     }),
+    audioUploader: f({
+      audio: {
+        maxFileSize: "4MB",
+        maxFileCount: 1,
+      },
+    })
+    .middleware(async ({ req }) => {
+      const user = await auth(req);
+      if (!user) throw new UploadThingError("Unauthorized");
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ metadata, file }) => {
+      console.log("Upload complete for userId:", metadata.userId);
+      console.log("file url", file.ufsUrl);
+      return { uploadedBy: metadata.userId };
+    }),
+
 } satisfies FileRouter;
 
 export type OurFileRouter = typeof ourFileRouter;

--- a/src/app/audio/page.tsx
+++ b/src/app/audio/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { UploadDropzone } from "~/utils/uploadthing";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+      <div className="w-full max-w-2xl">
+        <UploadDropzone
+          endpoint="audioUploader"
+          onClientUploadComplete={(res) => {
+            console.log("Files: ", res);
+            alert("Upload Completed");
+          }}
+          onUploadError={(error: Error) => {
+            alert(`ERROR! ${error.message}`);
+          }}
+          onUploadBegin={(name) => {
+            console.log("Uploading: ", name);
+          }}
+          config={{
+            mode: "auto"
+          }}
+        />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
This PR introduces a new route for uploading audio files (`/audio`) and a corresponding `audioUploader` endpoint in the `uploadthing` configuration.

Key changes:

*   Created a new `/audio` route with an `UploadDropzone` component configured to use the `audioUploader` endpoint.
*   Added an `audioUploader` endpoint to `src/app/api/uploadthing/core.ts`. This endpoint:
    *   Accepts audio files with a maximum size of 4MB and a maximum file count of 1.
    *   Logs the upload completion and file URL.
    *   Returns metadata about the uploaded file, including the user ID.

This change allows users to upload audio files to the application.
