### PR TITLE
Add PDF file route and endpoint

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -70,6 +70,22 @@ export const ourFileRouter = {
       console.log("file url", file.ufsUrl);
       return { uploadedBy: metadata.userId };
     }),
+    pdfUploader: f({
+      pdf: {
+        maxFileSize: "4MB",
+        maxFileCount: 1,
+      },
+    })
+    .middleware(async ({ req }) => {
+      const user = await auth(req);
+      if (!user) throw new UploadThingError("Unauthorized");
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ metadata, file }) => {
+      console.log("Upload complete for userId:", metadata.userId);
+      console.log("file url", file.ufsUrl);
+      return { uploadedBy: metadata.userId };
+    }),
 
 } satisfies FileRouter;
 

--- a/src/app/pdf/page.tsx
+++ b/src/app/pdf/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { UploadDropzone } from "~/utils/uploadthing";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+      <div className="w-full max-w-2xl">
+        <UploadDropzone
+          endpoint="pdfUploader"
+          onClientUploadComplete={(res) => {
+            console.log("Files: ", res);
+            alert("Upload Completed");
+          }}
+          onUploadError={(error: Error) => {
+            alert(`ERROR! ${error.message}`);
+          }}
+          onUploadBegin={(name) => {
+            console.log("Uploading: ", name);
+          }}
+          config={{
+            mode: "auto"
+          }}
+        />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
This PR introduces a new route for uploading PDF files (`/pdf`) and a corresponding `pdfUploader` endpoint in the `uploadthing` configuration.

Key changes:

*   Created a new `/pdf` route with an `UploadDropzone` component configured to use the `pdfUploader` endpoint.
*   Added a `pdfUploader` endpoint to `src/app/api/uploadthing/core.ts`. This endpoint:
    *   Accepts PDF files with a maximum size of 4MB and a maximum file count of 1.
    *   Uses middleware to authenticate the user.
    *   Logs the upload completion and file URL.
    *   Returns metadata about the uploaded file, including the user ID.

This change allows users to upload PDF files to the application.
