### PR TITLE
Add text endpoint and route

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -87,7 +87,7 @@ export const ourFileRouter = {
       return { uploadedBy: metadata.userId };
     }),
     textUploader: f({
-      pdf: {
+      text: {
         maxFileSize: "64KB",
         maxFileCount: 1,
       },

--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -86,6 +86,22 @@ export const ourFileRouter = {
       console.log("file url", file.ufsUrl);
       return { uploadedBy: metadata.userId };
     }),
+    textUploader: f({
+      pdf: {
+        maxFileSize: "64KB",
+        maxFileCount: 1,
+      },
+    })
+    .middleware(async ({ req }) => {
+      const user = await auth(req);
+      if (!user) throw new UploadThingError("Unauthorized");
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ metadata, file }) => {
+      console.log("Upload complete for userId:", metadata.userId);
+      console.log("file url", file.ufsUrl);
+      return { uploadedBy: metadata.userId };
+    }),
 
 } satisfies FileRouter;
 

--- a/src/app/text/page.tsx
+++ b/src/app/text/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { UploadDropzone } from "~/utils/uploadthing";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+      <div className="w-full max-w-2xl">
+        <UploadDropzone
+          endpoint="textUploader"
+          onClientUploadComplete={(res) => {
+            console.log("Files: ", res);
+            alert("Upload Completed");
+          }}
+          onUploadError={(error: Error) => {
+            alert(`ERROR! ${error.message}`);
+          }}
+          onUploadBegin={(name) => {
+            console.log("Uploading: ", name);
+          }}
+          config={{
+            mode: "auto"
+          }}
+        />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Description

This pull request introduces a new feature allowing users to upload text files. It includes a dedicated API endpoint for handling text file uploads and a new page with a UI component for users to select and upload their text files.

## Changes Included

*   **API Endpoint (`src/app/api/uploadthing/core.ts`):**
    *   Added a new `textUploader` endpoint to the `ourFileRouter`.
    *   This endpoint is configured to accept text files (`text`).
    *   It enforces a `maxFileSize` of "64KB" and `maxFileCount` of 1.
    *   Includes authentication middleware to ensure only authorized users can upload files.
    *   Logs upload completion and file URL.
    *   Corrected the file type to `text` (initially might have been a different type).

*   **Frontend Page (`src/app/text/page.tsx`):**
    *   Created a new page at the `/text` route.
    *   This page utilizes the `UploadDropzone` component from `~/utils/uploadthing`.
    *   The `UploadDropzone` is configured to use the `textUploader` endpoint.
    *   Includes client-side handlers for:
        *   `onClientUploadComplete`: Logs uploaded files and shows an alert.
        *   `onUploadError`: Shows an alert with the error message.
        *   `onUploadBegin`: Logs the name of the file being uploaded.
    *   The `config` for `UploadDropzone` is set to `mode: "auto"`.
