### PR TITLE
Added blob endpoint, route and home link

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -102,6 +102,22 @@ export const ourFileRouter = {
       console.log("file url", file.ufsUrl);
       return { uploadedBy: metadata.userId };
     }),
+    blobUploader: f({
+      blob: {
+        maxFileSize: "8MB",
+        maxFileCount: 1,
+      },
+    })
+    .middleware(async ({ req }) => {
+      const user = await auth(req);
+      if (!user) throw new UploadThingError("Unauthorized");
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ metadata, file }) => {
+      console.log("Upload complete for userId:", metadata.userId);
+      console.log("file url", file.ufsUrl);
+      return { uploadedBy: metadata.userId };
+    }),
 
 } satisfies FileRouter;
 

--- a/src/app/blob/page.tsx
+++ b/src/app/blob/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { UploadDropzone } from "~/utils/uploadthing";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+      <div className="w-full max-w-2xl">
+        <UploadDropzone
+          endpoint="blobUploader"
+          onClientUploadComplete={(res) => {
+            console.log("Files: ", res);
+            alert("Upload Completed");
+          }}
+          onUploadError={(error: Error) => {
+            alert(`ERROR! ${error.message}`);
+          }}
+          onUploadBegin={(name) => {
+            console.log("Uploading: ", name);
+          }}
+          config={{
+            mode: "auto"
+          }}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,12 @@ export default function Home() {
             <h2 className="text-xl font-semibold mb-2">Text Upload</h2>
             <p className="text-sm text-gray-600 dark:text-gray-400">Upload text files up to 64KB</p>
           </Link>
+
+          <Link href="/blob" className="p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+            <h2 className="text-xl font-semibold mb-2">Blob Upload</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Upload blob files up to 8MB</p>
+          </Link>
+
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Description

This pull request introduces functionality for uploading generic blob files. It includes a new API endpoint specifically for blob uploads, a dedicated page with an upload UI, and a link to this new page from the application's home page.

## Changes Included

*   **API Endpoint (`src/app/api/uploadthing/core.ts`):**
    *   Added a new `blobUploader` endpoint to the `ourFileRouter`.
    *   This endpoint is configured to accept generic blob files (`blob`).
    *   It enforces a `maxFileSize` of "8MB" and `maxFileCount` of 1.
    *   Includes authentication middleware to ensure only authorized users can upload files.
    *   Logs upload completion and file URL on the server side.

*   **Frontend Page (`src/app/blob/page.tsx`):**
    *   Created a new page at the `/blob` route.
    *   This page utilizes the `UploadDropzone` component from `~/utils/uploadthing`.
    *   The `UploadDropzone` is configured to use the new `blobUploader` endpoint.
    *   Includes client-side handlers for:
        *   `onClientUploadComplete`: Logs uploaded files and shows an "Upload Completed" alert.
        *   `onUploadError`: Shows an alert with the error message.
        *   `onUploadBegin`: Logs the name of the file being uploaded.
    *   The `config` for `UploadDropzone` is set to `mode: "auto"`.

*   **Home Page Link (`src/app/page.tsx`):**
    *   Added a new card/link on the home page that directs users to the `/blob` upload page.
    *   The link includes a title "Blob Upload" and a description "Upload blob files up to 8MB".