### PR TITLE
Enforce upload size limits on the client

### DIFF
--- a/src/components/upload-experience.tsx
+++ b/src/components/upload-experience.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { Effect } from "effect-beta";
 import {
+  FileTooLargeError,
   formatFileSize,
   getUploadErrorMessage,
   type PendingUploadFile,
@@ -167,7 +168,9 @@ export function UploadPageContent({ kind }: { kind: UploadKind }) {
       setErrorMessage(
         error instanceof UnsupportedFileTypeError
           ? `This route only accepts ${kind.accept.toLowerCase()}.`
-          : "The upload could not be prepared.",
+          : error instanceof FileTooLargeError
+            ? `This route accepts files up to ${kind.maxFileSize}.`
+            : "The upload could not be prepared.",
       );
     }
   }

--- a/src/modules/uploads/catalog.ts
+++ b/src/modules/uploads/catalog.ts
@@ -101,13 +101,13 @@ export const uploadKinds = [
   {
     slug: "blob",
     title: "Blob",
-    description: "Generic binary data",
-    limit: "Up to 8 MB",
+    description: "Generic binary data, including packet captures",
+    limit: "Up to 64 MB",
     endpoint: "blobUploader",
     accept: "Binary blobs",
     acceptAttr: "",
     fileType: "blob",
-    maxFileSize: "8MB",
+    maxFileSize: "64MB",
     maxFileCount: 1,
   },
 ] as const satisfies readonly UploadKind[];

--- a/src/modules/uploads/client.ts
+++ b/src/modules/uploads/client.ts
@@ -20,11 +20,39 @@ export class UnsupportedFileTypeError extends Schema.TaggedErrorClass("Unsupport
   },
 ) {}
 
+export class FileTooLargeError extends Schema.TaggedErrorClass("FileTooLargeError")(
+  "FileTooLargeError",
+  {
+    slug: UploadSlug,
+    fileName: Schema.String,
+    fileSize: Schema.Number,
+    maxFileSize: Schema.String,
+  },
+) {}
+
 const splitAcceptRules = (acceptAttr: string) =>
   acceptAttr
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean);
+
+const fileSizeUnitToBytes = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 * 1024,
+  GB: 1024 * 1024 * 1024,
+} as const;
+
+const parseFileSizeToBytes = (value: string) => {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)$/i);
+
+  if (!match) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const [, amount, unit] = match;
+  return Number(amount) * fileSizeUnitToBytes[unit.toUpperCase() as keyof typeof fileSizeUnitToBytes];
+};
 
 const matchesRule = (file: File, rule: string) =>
   Match.value(rule).pipe(
@@ -53,6 +81,17 @@ export const validateSelectedFile = Effect.fn("UploadClient.validateSelectedFile
       accept: kind.accept,
       fileName: file.name,
       mimeType: file.type,
+    });
+  }
+
+  const maxFileSizeInBytes = parseFileSizeToBytes(kind.maxFileSize);
+
+  if (file.size > maxFileSizeInBytes) {
+    return yield* new FileTooLargeError({
+      slug: kind.slug,
+      fileName: file.name,
+      fileSize: file.size,
+      maxFileSize: kind.maxFileSize,
     });
   }
 
@@ -85,6 +124,7 @@ export function getUploadErrorMessage(error: {
   readonly data: UploadRouteErrorData | undefined;
 }) {
   const details = error.data?.details?.trim();
+  const normalizedMessage = error.message.toLowerCase();
 
   return Match.value(error.data?.reason).pipe(
     Match.when(
@@ -99,7 +139,24 @@ export function getUploadErrorMessage(error: {
       "internal",
       () => details ?? "An unexpected upload error occurred.",
     ),
-    Match.orElse(() => error.message),
+    Match.orElse(() =>
+      Match.value(true).pipe(
+        Match.when(
+          () =>
+            normalizedMessage.includes("filesizemismatch") ||
+            normalizedMessage.includes("file size") ||
+            normalizedMessage.includes("too large"),
+          () => "The selected file exceeds this route's size limit.",
+        ),
+        Match.when(
+          () =>
+            normalizedMessage.includes("invalidfiletype") ||
+            normalizedMessage.includes("not allowed"),
+          () => "This file type is not allowed on this route.",
+        ),
+        Match.orElse(() => error.message),
+      ),
+    ),
   );
 }
 

--- a/src/modules/uploads/index.test.ts
+++ b/src/modules/uploads/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect-beta";
 import {
+  FileTooLargeError,
   UnsupportedFileTypeError,
   formatFileSize,
   getUploadErrorMessage,
@@ -36,6 +37,16 @@ describe("uploads module", () => {
     ).rejects.toBeInstanceOf(UnsupportedFileTypeError);
   });
 
+  test("rejects files that exceed the configured route size", async () => {
+    const file = new File([new Uint8Array(70 * 1024 * 1024)], "capture.pcapng", {
+      type: "application/octet-stream",
+    });
+
+    await expect(
+      Effect.runPromise(validateSelectedFile(file, getUploadKind("blob"))),
+    ).rejects.toBeInstanceOf(FileTooLargeError);
+  });
+
   test("formats structured uploadthing authorization errors for the UI", () => {
     expect(
       getUploadErrorMessage({
@@ -50,5 +61,14 @@ describe("uploads module", () => {
         },
       }),
     ).toBe("The upload route could not resolve a user identity.");
+  });
+
+  test("formats generic uploadthing size errors for the UI", () => {
+    expect(
+      getUploadErrorMessage({
+        message: "FileSizeMismatch: file size is too large",
+        data: undefined,
+      }),
+    ).toBe("The selected file exceeds this route's size limit.");
   });
 });

--- a/src/modules/uploads/index.ts
+++ b/src/modules/uploads/index.ts
@@ -1,6 +1,7 @@
 export { getUploadKind, getUploadKindEffect, UnknownUploadKindError, uploadKinds } from "./catalog";
 export type { UploadEndpoint, UploadFileType, UploadKind, UploadSlug } from "./catalog";
 export {
+  FileTooLargeError,
   formatFileSize,
   getUploadErrorMessage,
   getRouteConfig,


### PR DESCRIPTION
## Summary
- Added client-side validation for route-specific maximum file sizes and introduced a `FileTooLargeError` for oversized uploads.
- Updated the blob upload configuration from 8 MB to 64 MB, with matching copy in the upload catalog.
- Improved upload error messaging in the UI to surface clearer feedback for unsupported types and oversized files.
- Added tests covering oversized file rejection and generic size-error formatting.

## Testing
- `bun test src/modules/uploads/index.test.ts`
- Not run: full project test suite