### PR TITLE
Enforce blob upload size limits in client

### DIFF
--- a/src/components/upload-experience.tsx
+++ b/src/components/upload-experience.tsx
@@ -6,6 +6,7 @@ import {
   FileTooLargeError,
   formatFileSize,
   getUploadErrorMessage,
+  normalizeFileForUpload,
   type PendingUploadFile,
   type UploadKind,
   UnsupportedFileTypeError,
@@ -153,13 +154,14 @@ export function UploadPageContent({ kind }: { kind: UploadKind }) {
     if (!file || isUploading) return;
 
     try {
-      const nextPendingFile = await Effect.runPromise(validateSelectedFile(file, kind));
+      const uploadFile = normalizeFileForUpload(file, kind);
+      const nextPendingFile = await Effect.runPromise(validateSelectedFile(uploadFile, kind));
       setPendingFile(nextPendingFile);
       setUploadedUrl(null);
       setErrorMessage(null);
       setStatusMessage("Preparing upload");
       setUploadProgress(0);
-      await startUpload([file]);
+      await startUpload([uploadFile]);
     } catch (error) {
       setPendingFile(null);
       setUploadedUrl(null);

--- a/src/components/upload-experience.tsx
+++ b/src/components/upload-experience.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { Effect } from "effect-beta";
 import {
+  FileTooLargeError,
   formatFileSize,
   getUploadErrorMessage,
   type PendingUploadFile,
@@ -167,7 +168,9 @@ export function UploadPageContent({ kind }: { kind: UploadKind }) {
       setErrorMessage(
         error instanceof UnsupportedFileTypeError
           ? `This route only accepts ${kind.accept.toLowerCase()}.`
-          : "The upload could not be prepared.",
+          : error instanceof FileTooLargeError
+            ? `This route accepts files up to ${kind.maxFileSize}.`
+            : "The upload could not be prepared.",
       );
     }
   }

--- a/src/modules/uploads/catalog.ts
+++ b/src/modules/uploads/catalog.ts
@@ -101,13 +101,13 @@ export const uploadKinds = [
   {
     slug: "blob",
     title: "Blob",
-    description: "Generic binary data",
-    limit: "Up to 8 MB",
+    description: "Generic binary data, including packet captures",
+    limit: "Up to 64 MB",
     endpoint: "blobUploader",
     accept: "Binary blobs",
     acceptAttr: "",
     fileType: "blob",
-    maxFileSize: "8MB",
+    maxFileSize: "64MB",
     maxFileCount: 1,
   },
 ] as const satisfies readonly UploadKind[];

--- a/src/modules/uploads/client.ts
+++ b/src/modules/uploads/client.ts
@@ -20,11 +20,39 @@ export class UnsupportedFileTypeError extends Schema.TaggedErrorClass("Unsupport
   },
 ) {}
 
+export class FileTooLargeError extends Schema.TaggedErrorClass("FileTooLargeError")(
+  "FileTooLargeError",
+  {
+    slug: UploadSlug,
+    fileName: Schema.String,
+    fileSize: Schema.Number,
+    maxFileSize: Schema.String,
+  },
+) {}
+
 const splitAcceptRules = (acceptAttr: string) =>
   acceptAttr
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean);
+
+const fileSizeUnitToBytes = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 * 1024,
+  GB: 1024 * 1024 * 1024,
+} as const;
+
+const parseFileSizeToBytes = (value: string) => {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)$/i);
+
+  if (!match) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const [, amount, unit] = match;
+  return Number(amount) * fileSizeUnitToBytes[unit.toUpperCase() as keyof typeof fileSizeUnitToBytes];
+};
 
 const matchesRule = (file: File, rule: string) =>
   Match.value(rule).pipe(
@@ -53,6 +81,17 @@ export const validateSelectedFile = Effect.fn("UploadClient.validateSelectedFile
       accept: kind.accept,
       fileName: file.name,
       mimeType: file.type,
+    });
+  }
+
+  const maxFileSizeInBytes = parseFileSizeToBytes(kind.maxFileSize);
+
+  if (file.size > maxFileSizeInBytes) {
+    return yield* new FileTooLargeError({
+      slug: kind.slug,
+      fileName: file.name,
+      fileSize: file.size,
+      maxFileSize: kind.maxFileSize,
     });
   }
 
@@ -85,6 +124,7 @@ export function getUploadErrorMessage(error: {
   readonly data: UploadRouteErrorData | undefined;
 }) {
   const details = error.data?.details?.trim();
+  const normalizedMessage = error.message.toLowerCase();
 
   return Match.value(error.data?.reason).pipe(
     Match.when(
@@ -99,7 +139,24 @@ export function getUploadErrorMessage(error: {
       "internal",
       () => details ?? "An unexpected upload error occurred.",
     ),
-    Match.orElse(() => error.message),
+    Match.orElse(() =>
+      Match.value(true).pipe(
+        Match.when(
+          () =>
+            normalizedMessage.includes("filesizemismatch") ||
+            normalizedMessage.includes("file size") ||
+            normalizedMessage.includes("too large"),
+          () => "The selected file exceeds this route's size limit.",
+        ),
+        Match.when(
+          () =>
+            normalizedMessage.includes("invalidfiletype") ||
+            normalizedMessage.includes("not allowed"),
+          () => "This file type is not allowed on this route.",
+        ),
+        Match.orElse(() => error.message),
+      ),
+    ),
   );
 }
 

--- a/src/modules/uploads/client.ts
+++ b/src/modules/uploads/client.ts
@@ -30,6 +30,17 @@ export class FileTooLargeError extends Schema.TaggedErrorClass("FileTooLargeErro
   },
 ) {}
 
+export const normalizeFileForUpload = (file: File, kind: UploadKind) => {
+  if (kind.fileType !== "blob" || file.type === "application/octet-stream") {
+    return file;
+  }
+
+  return new File([file], file.name, {
+    type: "application/octet-stream",
+    lastModified: file.lastModified,
+  });
+};
+
 const splitAcceptRules = (acceptAttr: string) =>
   acceptAttr
     .split(",")

--- a/src/modules/uploads/index.test.ts
+++ b/src/modules/uploads/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect-beta";
 import {
+  FileTooLargeError,
   UnsupportedFileTypeError,
   formatFileSize,
   getUploadErrorMessage,
@@ -36,6 +37,16 @@ describe("uploads module", () => {
     ).rejects.toBeInstanceOf(UnsupportedFileTypeError);
   });
 
+  test("rejects files that exceed the configured route size", async () => {
+    const file = new File([new Uint8Array(70 * 1024 * 1024)], "capture.pcapng", {
+      type: "application/octet-stream",
+    });
+
+    await expect(
+      Effect.runPromise(validateSelectedFile(file, getUploadKind("blob"))),
+    ).rejects.toBeInstanceOf(FileTooLargeError);
+  });
+
   test("formats structured uploadthing authorization errors for the UI", () => {
     expect(
       getUploadErrorMessage({
@@ -50,5 +61,14 @@ describe("uploads module", () => {
         },
       }),
     ).toBe("The upload route could not resolve a user identity.");
+  });
+
+  test("formats generic uploadthing size errors for the UI", () => {
+    expect(
+      getUploadErrorMessage({
+        message: "FileSizeMismatch: file size is too large",
+        data: undefined,
+      }),
+    ).toBe("The selected file exceeds this route's size limit.");
   });
 });

--- a/src/modules/uploads/index.test.ts
+++ b/src/modules/uploads/index.test.ts
@@ -6,6 +6,7 @@ import {
   formatFileSize,
   getUploadErrorMessage,
   getUploadKind,
+  normalizeFileForUpload,
   uploadKinds,
   validateSelectedFile,
 } from "./index";
@@ -45,6 +46,20 @@ describe("uploads module", () => {
     await expect(
       Effect.runPromise(validateSelectedFile(file, getUploadKind("blob"))),
     ).rejects.toBeInstanceOf(FileTooLargeError);
+  });
+
+  test("normalizes blob uploads to application/octet-stream", () => {
+    const file = new File(["pcap"], "capture.pcapng", {
+      type: "application/x-pcapng",
+      lastModified: 123,
+    });
+
+    const normalized = normalizeFileForUpload(file, getUploadKind("blob"));
+
+    expect(normalized).not.toBe(file);
+    expect(normalized.name).toBe("capture.pcapng");
+    expect(normalized.type).toBe("application/octet-stream");
+    expect(normalized.lastModified).toBe(123);
   });
 
   test("formats structured uploadthing authorization errors for the UI", () => {

--- a/src/modules/uploads/index.ts
+++ b/src/modules/uploads/index.ts
@@ -5,6 +5,7 @@ export {
   formatFileSize,
   getUploadErrorMessage,
   getRouteConfig,
+  normalizeFileForUpload,
   PendingUploadFile,
   UnsupportedFileTypeError,
   useUploadThing,

--- a/src/modules/uploads/index.ts
+++ b/src/modules/uploads/index.ts
@@ -1,6 +1,7 @@
 export { getUploadKind, getUploadKindEffect, UnknownUploadKindError, uploadKinds } from "./catalog";
 export type { UploadEndpoint, UploadFileType, UploadKind, UploadSlug } from "./catalog";
 export {
+  FileTooLargeError,
   formatFileSize,
   getUploadErrorMessage,
   getRouteConfig,


### PR DESCRIPTION
## Summary
- Normalize blob uploads to `application/octet-stream` before client-side validation and submission.
- Add client-side size checks for upload routes and surface a specific `FileTooLargeError`.
- Increase the blob route limit to 64 MB and update UI error messaging for size and type failures.
- Add tests covering blob normalization, oversized file rejection, and size-error formatting.

## Testing
- `bun test src/modules/uploads/index.test.ts`
- Not run: full repository test suite
- Not run: manual upload flow verification in the browser