### PR TITLE
Improve fallback messaging for upload errors

### DIFF
--- a/src/modules/uploads/client.ts
+++ b/src/modules/uploads/client.ts
@@ -134,20 +134,23 @@ export function getUploadErrorMessage(error: {
   readonly data: UploadRouteErrorData | undefined;
 }) {
   const details = error.data?.details?.trim();
+  const formattedMessage = error.data?.message?.trim();
+  const causeMessage = error.data?.causeMessage?.trim();
   const normalizedMessage = error.message.toLowerCase();
 
   return Match.value(error.data?.reason).pipe(
     Match.when(
       "authorization",
-      () => details ?? "You must be signed in before uploading files.",
+      () => details ?? formattedMessage ?? "You must be signed in before uploading files.",
     ),
     Match.when(
       "completion",
-      () => details ?? "The file uploaded, but the server could not finish processing it.",
+      () =>
+        details ?? causeMessage ?? formattedMessage ?? "The file uploaded, but the server could not finish processing it.",
     ),
     Match.when(
       "internal",
-      () => details ?? "An unexpected upload error occurred.",
+      () => details ?? causeMessage ?? formattedMessage ?? "An unexpected upload error occurred.",
     ),
     Match.orElse(() =>
       Match.value(true).pipe(
@@ -163,6 +166,10 @@ export function getUploadErrorMessage(error: {
             normalizedMessage.includes("invalidfiletype") ||
             normalizedMessage.includes("not allowed"),
           () => "This file type is not allowed on this route.",
+        ),
+        Match.when(
+          () => error.message === error.message.toUpperCase() && error.message.includes("_"),
+          () => formattedMessage ?? causeMessage ?? "The upload provider rejected this file.",
         ),
         Match.orElse(() => error.message),
       ),

--- a/src/modules/uploads/index.test.ts
+++ b/src/modules/uploads/index.test.ts
@@ -67,11 +67,13 @@ describe("uploads module", () => {
         message: "Failed to run middleware",
         data: {
           code: "FORBIDDEN",
+          message: "You must be signed in to upload files.",
           reason: "authorization",
           route: "image",
           fileKey: null,
           details: "The upload route could not resolve a user identity.",
           causeTag: "UploadAuthorizationError",
+          causeMessage: "UploadAuthorizationError",
         },
       }),
     ).toBe("The upload route could not resolve a user identity.");
@@ -84,5 +86,23 @@ describe("uploads module", () => {
         data: undefined,
       }),
     ).toBe("The selected file exceeds this route's size limit.");
+  });
+
+  test("formats opaque uploadthing provider errors with structured fallback details", () => {
+    expect(
+      getUploadErrorMessage({
+        message: "UPLOAD_FAILED",
+        data: {
+          code: "UPLOAD_FAILED",
+          message: "UploadThing could not store this file.",
+          reason: "internal",
+          route: "blob",
+          fileKey: null,
+          details: "File upload rejected by the upstream provider.",
+          causeTag: null,
+          causeMessage: "Possible malware or unsupported binary signature.",
+        },
+      }),
+    ).toBe("File upload rejected by the upstream provider.");
   });
 });

--- a/src/modules/uploads/server.ts
+++ b/src/modules/uploads/server.ts
@@ -23,11 +23,13 @@ class UploadCompletionError extends Schema.TaggedErrorClass("UploadCompletionErr
 
 export type UploadRouteErrorData = {
   readonly code: string;
+  readonly message: string | null;
   readonly reason: "authorization" | "completion" | "internal";
   readonly route: string | null;
   readonly fileKey: string | null;
   readonly details: string | null;
   readonly causeTag: string | null;
+  readonly causeMessage: string | null;
 };
 
 const isUploadRouteErrorData = (value: unknown): value is UploadRouteErrorData =>
@@ -42,14 +44,19 @@ const formatUploadErrorData = (error: UploadThingError): UploadRouteErrorData =>
 
   return {
     code: error.code,
+    message: error.message,
     reason: data?.reason ?? "internal",
     route: data?.route ?? null,
     fileKey: data?.fileKey ?? null,
-    details: data?.details ?? null,
+    details:
+      data?.details ??
+      (cause instanceof Error ? cause.message : typeof cause === "string" ? cause : null),
     causeTag:
       cause && typeof cause === "object" && "_tag" in cause && typeof cause._tag === "string"
         ? cause._tag
         : null,
+    causeMessage:
+      cause instanceof Error ? cause.message : typeof cause === "string" ? cause : null,
   };
 };
 
@@ -72,11 +79,13 @@ const toUploadThingError = (error: unknown): UploadThingError<UploadRouteErrorDa
           cause,
           data: {
             code: "FORBIDDEN",
+            message: "You must be signed in to upload files.",
             reason: "authorization",
             route: cause.route,
             fileKey: null,
             details: cause.details,
             causeTag: cause._tag,
+            causeMessage: cause.message,
           },
         }),
     ),
@@ -89,11 +98,13 @@ const toUploadThingError = (error: unknown): UploadThingError<UploadRouteErrorDa
           cause,
           data: {
             code: "UPLOAD_FAILED",
+            message: "The upload finished, but the server could not finalize it.",
             reason: "completion",
             route: cause.route,
             fileKey: cause.fileKey,
             details: cause.details,
             causeTag: cause._tag,
+            causeMessage: cause.message,
           },
         }),
     ),
@@ -105,6 +116,7 @@ const toUploadThingError = (error: unknown): UploadThingError<UploadRouteErrorDa
           cause,
           data: {
             code: "INTERNAL_SERVER_ERROR",
+            message: "An unexpected upload error occurred.",
             reason: "internal",
             route: null,
             fileKey: null,
@@ -113,6 +125,8 @@ const toUploadThingError = (error: unknown): UploadThingError<UploadRouteErrorDa
               cause && typeof cause === "object" && "_tag" in cause && typeof cause._tag === "string"
                 ? cause._tag
                 : null,
+            causeMessage:
+              cause instanceof Error ? cause.message : typeof cause === "string" ? cause : null,
           },
         }),
     ),


### PR DESCRIPTION
## Summary
- Preserve richer error context from upload failures by carrying through structured `message` and `causeMessage` fields.
- Improve client-side fallback selection so authorization, completion, and internal upload errors surface more useful messages.
- Add coverage for structured fallback behavior when provider errors are opaque or generic.

## Testing
- `src/modules/uploads/index.test.ts`: added a case covering structured fallback messaging for provider-upload failures.
- Not run: full test suite.
- Not run: typecheck/build verification.